### PR TITLE
Added preview-release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ livereload
 # [I 150619 19:22:15 handlers:118] Start watching changes
 ```
 
+### Publishing a preview
+When submitting a pull request, it is nice to be able to preview changes to the website. We have build `npm run preview-release` for that purpose.
+
+When you run it, it will publish the current branch's build to `{{branch}}.preview` (e.g. `dev/hello` -> `dev/hello.preview`). This branch should be accessible via <https://htmlpreview.github.io/>
+
+```bash
+# Publish a preview branch
+npm run preview-release
+
+# Access the preview via htmlpreview.github.io
+# http://htmlpreview.github.io/?https://github.com/underdogio/underdogio.github.io/blob/{{preview_branch}}/index.html
+```
+
 ### Releasing
 We have automated our release process to keep it consistent among developers. Before releasing, please make sure to update the `CHANGELOG.md`.
 

--- a/bin/preview-release.sh
+++ b/bin/preview-release.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Exit on the first error and echo commands
+set -e
+set -x
+
+# Build our files
+npm run build
+
+# Update all `article` URLs to include an `index.html`
+# DEV: Without this change, links between articles wouldn't work on htmlpreview.github.com
+#   `href="/articles/roll-call-todd/"` -> `href="/articles/roll-call-todd/index.html"`
+# DEV: This must come before we prepend `/underdogio` to URLs
+shopt -s globstar
+sed -E "s/( href=\"\/articles\/[^\"]+)\/\"/\1\/index.html\"/" build/**/*.html --in-place
+shopt -u globstar
+
+# Update the absolute paths (but not absolute URLs) to be prefixed with repo
+# DEV: This is necessary for raw.githubcontent.com
+#   `/css/main.css` -> `/underdogio/underdogio.github.io/my-preview-branch/css/main.css`
+branch="$(git symbolic-ref HEAD --short)"
+preview_branch="$branch.preview"
+escaped_preview_branch="$(echo $preview_branch | sed -E "s/\\//\\\\\//g")"
+shopt -s globstar
+sed -E "s/( href=)\"\/([^\"]+)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
+sed -E "s/( src=)\"\/([^\"]+)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
+shopt -u globstar
+
+# Publish our folder
+./node_modules/.bin/gh-pages --dist build/ --branch "$preview_branch"
+
+# Silence extra noise
+set +x
+
+# Notify ourselves of the successful build
+echo "A preview of underdogio.github.io has been built and pushed to the \`$preview_branch\` branch"
+echo "Please view it at http://htmlpreview.github.io/?https://github.com/underdogio/underdogio.github.io/blob/$preview_branch/index.html"
+exit 0

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -19,6 +19,9 @@ git push origin --tags
 # Publish the compiled version to `gh-pages`
 npm run _deploy
 
+# Silence extra noise
+set +x
+
 # Notify ourselves of the successful build
 echo "underdogio.github.io has been built and deployed successfully as \"$version\""
 echo "Please verify changes at http://underdogio.github.io/"

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "build": "wintersmith build && echo \"engineering.underdog.io\" > build/CNAME",
+    "build": "npm run clean && wintersmith build && echo \"engineering.underdog.io\" > build/CNAME",
+    "clean": "if test -d build/; then rm -r build/; fi",
     "deploy": "echo \"Do not run this command directly. Instead, please run \\`bin/release.sh\\` as documented in README.md\" && exit 1",
     "_deploy": "test -d build/ && gh-pages --dist build/ --branch master",
+    "preview-release": "bin/preview-release.sh",
     "release": "bin/release.sh",
     "start": "wintersmith preview",
     "test": "bin/test.sh"


### PR DESCRIPTION
We were getting frustrated at the lack of ability to show a preview of what the new version of the site is going to look like. In order to patch that, we are introducing preview branches hosted courtesy of GitHub/htmlpreview.github.io. For demonstration, here's this branch's preview:

http://htmlpreview.github.io/?https://github.com/underdogio/underdogio.github.io/blob/dev/add.preview.command.preview/index.html

In this PR:
- Added `preview-release` command
- Added cleanup to `build` (we had some folders not being cleaned up on each new build)
- Added documentation

/cc @brettlangdon 
