### PR TITLE
Repaired/documented OS X support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ npm run preview-release
 # http://htmlpreview.github.io/?https://github.com/underdogio/underdogio.github.io/blob/{{preview_branch}}/index.html
 ```
 
+#### OS X Troubleshooting
+If you are on OS X and running into issues (e.g. `globstar` isn't defined and `sed` doesn't support `--in-place`), then please upgrade your `bash` to `>=4.0.0` and install `gnu-sed`:
+
+- `bash`
+    - Upgrade available via shellshock test sites
+        - https://shellshocker.net/
+        - `curl https://shellshocker.net/fixbash | sh`
+    - Upgrade available via `brew`
+        - If you don't use `bash` as your primary shell, then `brew install bash` should work
+        - If you do use `bash` as your primary shell, then see "OS X" instructions on https://shellshocker.net/
+- Install `gnu-sed` via `homebrew`
+    - `brew install gnu-sed`
+    - This installs `gsed` to your command line
+
 ### Releasing
 We have automated our release process to keep it consistent among developers. Before releasing, please make sure to update the `CHANGELOG.md`.
 

--- a/bin/preview-release.sh
+++ b/bin/preview-release.sh
@@ -6,12 +6,18 @@ set -x
 # Build our files
 npm run build
 
+# If we are on OS X, try to use `gsed` before `sed` for `--in-place` support
+sed="sed"
+if which gsed &> /dev/null; then
+  sed="gsed"
+fi
+
 # Update all `article` URLs to include an `index.html`
 # DEV: Without this change, links between articles wouldn't work on htmlpreview.github.com
 #   `href="/articles/roll-call-todd/"` -> `href="/articles/roll-call-todd/index.html"`
 # DEV: This must come before we prepend `/underdogio` to URLs
 shopt -s globstar
-sed -E "s/( href=\"\/articles\/[^\"]+)\/\"/\1\/index.html\"/" build/**/*.html --in-place
+$sed -E "s/( href=\"\/articles\/[^\"]+)\/\"/\1\/index.html\"/" build/**/*.html --in-place
 shopt -u globstar
 
 # Update the absolute paths (but not absolute URLs) to be prefixed with repo
@@ -19,10 +25,10 @@ shopt -u globstar
 #   `/css/main.css` -> `/underdogio/underdogio.github.io/my-preview-branch/css/main.css`
 branch="$(git symbolic-ref HEAD --short)"
 preview_branch="$branch.preview"
-escaped_preview_branch="$(echo $preview_branch | sed -E "s/\\//\\\\\//g")"
+escaped_preview_branch="$(echo $preview_branch | $sed -E "s/\\//\\\\\//g")"
 shopt -s globstar
-sed -E "s/( href=)\"\/([^\"]+)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
-sed -E "s/( src=)\"\/([^\"]+)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
+$sed -E "s/( href=)\"\/([^\"]+)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
+$sed -E "s/( src=)\"\/([^\"]+)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
 shopt -u globstar
 
 # Publish our folder


### PR DESCRIPTION
When attempting to generate a preview branch on OSX, we ran into a bunch of errors with `globstar` and `sed`. This PR repairs those and documents how we want to handle them. In this PR:
- Added `bash` upgrade documentation for `globstar` support
- Added `gsed` installation documentation
- Added logic to use `gsed` over `sed` if available for better OSX support

/cc @brettlangdon 
