### PR TITLE
Repaired HTTP font on HTTPS for preview

### DIFF
--- a/bin/preview-release.sh
+++ b/bin/preview-release.sh
@@ -23,12 +23,13 @@ shopt -u globstar
 # Update the absolute paths (but not absolute URLs) to be prefixed with repo
 # DEV: This is necessary for raw.githubcontent.com
 #   `/css/main.css` -> `/underdogio/underdogio.github.io/my-preview-branch/css/main.css`
+#   `//fonts.googleapis.com/` -> `//fonts.googleapis.com/`
 branch="$(git symbolic-ref HEAD --short)"
 preview_branch="$branch.preview"
 escaped_preview_branch="$(echo $preview_branch | $sed -E "s/\\//\\\\\//g")"
 shopt -s globstar
-$sed -E "s/( href=)\"\/([^\"]+)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
-$sed -E "s/( src=)\"\/([^\"]+)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
+$sed -E "s/( href=)\"\/([^\/][^\"]*)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
+$sed -E "s/( src=)\"\/([^\/][^\"]*)/\1\"\/underdogio\/underdogio.github.io\/$escaped_preview_branch\/\2/" build/**/*.html --in-place
 shopt -u globstar
 
 # Publish our folder

--- a/templates/layout.jade
+++ b/templates/layout.jade
@@ -11,7 +11,7 @@ html(lang='en')
         block title
           = locals.name
       link(rel='alternate', href=locals.url+'/feed.xml', type='application/rss+xml', title=locals.description)
-      link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Lato:400,700|Anonymous+Pro:400,700,400italic,700italic')
+      link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Lato:400,700|Anonymous+Pro:400,700,400italic,700italic')
       link(rel='stylesheet', href=contents.css['main.css'].url)
   body(class=bodyclass)
     header.header


### PR DESCRIPTION
**Depends on #6**

When reviewing #5, I noticed the font for Lato wasn't loading. When inspecting this, it was caused by using an HTTP URL when the rest of the site was being loaded over HTTPS. To repair this, we are moving to a protocol-less fonts URL. In this PR:
- Moved to `http://fonts.googleapis.com/` to `//fonts.googleapis.com/` to inherit same protocol as page
- Updated `sed` replacements to not replace `//` as it looks like a path instead of a full URL

Preview: http://htmlpreview.github.io/?https://github.com/underdogio/underdogio.github.io/blob/dev/actual.font.fix.preview/index.html

/cc @brettlangdon 
