### PR TITLE
Add Google analytics tracking to blog

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,11 +1,21 @@
 {
-  "locals": {
-    "url": "http://engineering.underdog.io",
-    "name": "Underdog.io Engineering blog",
-    "owner": "Underdog.io Engineering",
-    "description": "Articles and insights from the Underdog.io Engineering team"
+  "env-locals": {
+    "common": {
+      "description": "Articles and insights from the Underdog.io Engineering team",
+      "ga_id": "UA-64967323-1",
+      "name": "Underdog.io Engineering blog",
+      "owner": "Underdog.io Engineering",
+      "url": "http://localhost:8080"
+    },
+    "development": {
+    },
+    "production": {
+      "ga_id": "UA-49880770-1",
+      "url": "http://engineering.underdog.io"
+    }
   },
   "plugins": [
+    "./plugins/env-locals.js",
     "./plugins/paginator.coffee"
   ],
   "require": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "build": "npm run clean && wintersmith build && echo \"engineering.underdog.io\" > build/CNAME",
+    "build": "export NODE_ENV=production; npm run clean && wintersmith build && echo \"engineering.underdog.io\" > build/CNAME",
     "clean": "if test -d build/; then rm -r build/; fi",
     "deploy": "echo \"Do not run this command directly. Instead, please run \\`bin/release.sh\\` as documented in README.md\" && exit 1",
     "_deploy": "test -d build/ && gh-pages --dist build/ --branch master",
@@ -39,6 +39,7 @@
   "devDependencies": {
     "gh-pages": "~0.3.1",
     "moment": "~2.3.0",
+    "shallow-settings": "~0.1.0",
     "typogr": "~0.5.0",
     "underscore": "~1.4.0",
     "wintersmith": "~2.2.0"

--- a/plugins/env-locals.js
+++ b/plugins/env-locals.js
@@ -1,0 +1,11 @@
+var Settings = require('shallow-settings');
+var _ = require('underscore');
+
+module.exports = function (env, callback) {
+  var node_env = process.env.NODE_ENV || 'development';
+  var settings = new Settings(env.config['env-locals']);
+  // DEV: Do not override `env.locals`, we will lose `typogr`, `_`, `moment`, and etc
+  env.locals = _.extend(env.locals, settings.getSettings({env: node_env}));
+
+  callback();
+};

--- a/templates/layout.jade
+++ b/templates/layout.jade
@@ -31,3 +31,14 @@ html(lang='en')
             p &copy; #{ new Date().getFullYear() } #{ locals.owner } &mdash; powered by&nbsp;
               a(href='https://github.com/jnordberg/wintersmith') Wintersmith
               //- please leave the "powered by" if you use the design
+    //- Environment settings
+    script.
+      window.env = {gaId: '#{locals.ga_id}'};
+    //- Google analytics
+    script.
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      ga('create', window.env.gaId, 'auto');
+      ga('send', 'pageview');


### PR DESCRIPTION
Like the title suggests, this PR is to add google analytics tracking to the blog.

This is the same GA tracking id used for the underdog.io and blog.underdog.io (at the request of josh).

/cc @twolfson 
